### PR TITLE
Add coordinate copying functionality

### DIFF
--- a/script.js
+++ b/script.js
@@ -165,14 +165,43 @@ function displayResults(crossroads) {
     }
 
     for (let i = 0; i < crossroads.length; i++) {
-        crossroad = crossroads[i];
+        let crossroad = crossroads[i];
 
         const resultRow = document.createElement('span')
         resultRow.className = 'result-row';
         resultRow.innerText = `${crossroad[0]} ${crossroad[1]} ${crossroad[2]}`;
 
+        resultRow.addEventListener('click', ()=>copyCoordinatesToClipboard(resultRow))
+
         resultsContainer.appendChild(resultRow)
     }
+}
+
+
+function copyCoordinatesToClipboard(resultRow) {
+    if (resultRow.disabled) return;
+
+    resultRow.disabled = true;
+
+    const coords = resultRow.innerText;
+
+    navigator.clipboard.writeText(`/tp @s ${coords.trim()}`)
+
+    resultRow.innerText = 'Copied!'
+    resultRow.classList.add('clicked')
+
+    setTimeout(
+        () => {
+            resultRow.classList.remove('clicked')
+        }, 150
+    )
+
+    setTimeout(
+        () => {
+            resultRow.innerText = coords;
+            resultRow.disabled = false;
+        }, 500
+    );
 }
 
 

--- a/style.css
+++ b/style.css
@@ -170,6 +170,10 @@ button:disabled {
     background-color: rgb(134, 115, 115);
 }
 
+.result-row.clicked {
+    background-color: #adff2f;
+    transform: scale(0.95, 0.95);
+}
 
 /*Small screens*/
 @media only screen and (max-width:1100px) {


### PR DESCRIPTION
<!-- !! Thank you for opening a PR !! ❤️❤️ -->

<!--- Provide a short summary of your changes in the Title above -->

## Description
Clicking the result rows copies the coordinates in them to the clipboard as a tp command (`/tp @s <x> <y> <z>`)

## Related Issue
<!--- If applicable, please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [x] Closes #2 
- [ ] Related to #

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [x] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):